### PR TITLE
Fix checkmark showing on load

### DIFF
--- a/components/d2l-module-link.html
+++ b/components/d2l-module-link.html
@@ -209,7 +209,8 @@
 					},
 					selectedModule: {
 						type: String,
-						value: ''
+						value: '',
+						notify: true
 					},
 					completionCount: {
 						type: Object,
@@ -328,6 +329,7 @@
 				if (!this.completionCount || this.completionCount.total === 0) return 0;
 				this.percentCompleted = 100 * this.completionCount.completed / this.completionCount.total;
 			}
+
 			_hasChildren(entity) {
 				return entity.getSubEntities().length !== 0;
 			}

--- a/components/d2l-module-link.html
+++ b/components/d2l-module-link.html
@@ -203,6 +203,10 @@
 						notify: true,
 						observer: '_closeModule'
 					},
+					hasCurrentActivity: {
+						type: Boolean,
+						value: false
+					},
 					selectedModule: {
 						type: String,
 						value: ''
@@ -226,17 +230,17 @@
 					showCount: {
 						type: Boolean,
 						value: false,
-						computed: '_showCount(completionCount, selectedModule)'
+						computed: '_showCount(completionCount, selectedModule, hasCurrentActivity)'
 					},
 					showCheckmark: {
 						type: Boolean,
 						value: false,
-						computed: '_showCheckmark(completionCount, selectedModule)'
+						computed: '_showCheckmark(completionCount, selectedModule, hasCurrentActivity)'
 					},
 					showOptional: {
 						type: Boolean,
 						value: false,
-						computed: '_showOptional(completionCount, selectedModule)'
+						computed: '_showOptional(completionCount, selectedModule, hasCurrentActivity)'
 					},
 					showDivider: {
 						type: Boolean,
@@ -274,10 +278,7 @@
 				return this.completionCount && this.completionCount.total > 0 && this.completionCount.completed > 0 && this.completionCount.completed <  this.completionCount.total;
 			}
 
-			_showCount(completionCount) {
-				if ( !completionCount ) {
-					return false;
-				}
+			_showCount() {
 				return this.hasChildren &&
 					!this._isOptionalModule() && (
 					this._isAccordionOpen() ||
@@ -285,20 +286,14 @@
 				);
 			}
 
-			_showCheckmark(completionCount) {
-				if ( !completionCount ) {
-					return false;
-				}
+			_showCheckmark() {
 				return !this._isAccordionOpen() && (
 					( this._isOptionalModule() && this._isAllOptionalViewed() ) ||
 					( !this._isOptionalModule() && this._isAllRequiredViewed() )
 				);
 			}
 
-			_showOptional(completionCount) {
-				if ( !completionCount ) {
-					return false;
-				}
+			_showOptional() {
 				return this._isOptionalModule() && !this._isAccordionOpen() && !this._isAllOptionalViewed();
 			}
 
@@ -359,8 +354,10 @@
 			_getIsCurrent(childLink, currentActivity) {
 				if ( childLink.href === currentActivity ) {
 					this.shadowRoot.querySelector('#moduleLink').setAttribute('opened', '');
+					this.hasCurrentActivity = true;
 					return 'current';
 				}
+				this.hasCurrentActivity = false;
 			}
 
 			_closeModule() {

--- a/d2l-sequence-navigator.html
+++ b/d2l-sequence-navigator.html
@@ -84,6 +84,7 @@
 							href="[[childLink.href]]"
 							token="[[token]]"
 							current-activity="{{href}}"
+							selected-module="{{selected-module}}"
 						>
 						</d2l-sequence-navigator-item>
 					</li>


### PR DESCRIPTION
When the ASV loads with a current activity of a completed open module, it would show the checkmark instead of the count.
- Fixing when the showX methods will retrigger
- Fixing the broken selectedModule logic