### PR TITLE
Refactor to use polymer-siren-behaviors instead of polymer-siren-mixins

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,12 +18,12 @@
   "dependencies": {
     "polymer": "Polymer/polymer#^2.0.0",
     "d2l-accordion": "^1.0.6",
-    "polymer-siren-mixins": "Brightspace/polymer-siren-mixins",
     "siren-entity": "BrightspaceHypermediaComponents/siren-entity",
     "d2l-typography": "^6.1.3",
     "d2l-icons": "^4.14.0 || ^5.0.0",
     "d2l-localize-behavior": "^1.1.1",
-    "d2l-offscreen": "^3.0.3"
+    "d2l-offscreen": "^3.0.3",
+    "d2l-polymer-siren-behaviors": "Brightspace/polymer-siren-behaviors#^0.0.3"
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^3.0.0",

--- a/components/d2l-activity-link.html
+++ b/components/d2l-activity-link.html
@@ -86,7 +86,7 @@
 		@memberOf window.D2L.Polymer.Mixins;
 		@mixes D2L.Polymer.Mixins.CompletionStatusMixin
 		*/
-		class D2LActivityLink extends D2L.Polymer.Mixins.CompletionStatusMixin( Polymer.Element ) {
+		class D2LActivityLink extends D2L.Polymer.Mixins.CompletionStatusMixin() {
 			static get is() {
 				return 'd2l-activity-link';
 			}
@@ -127,12 +127,12 @@
 			}
 
 			setCurrent() {
-				this.currentActivity = this._getLinkByRel( this.entity, 'self').href;
+				this.currentActivity = this.entity && this.entity.getLinkByRel('self').href;
 			}
 
 			onCurrentActivityChanged( currentActivity, entity ) {
 				if ( currentActivity && entity ) {
-					var current = this._getLinkByRel( entity, 'self').href === currentActivity;
+					var current = entity.getLinkByRel('self').href === currentActivity;
 					if ( current ) {
 						this.$.activityLink.classList.add('current');
 					} else {

--- a/components/d2l-completion-requirement.html
+++ b/components/d2l-completion-requirement.html
@@ -1,9 +1,7 @@
-<link rel="import" href="../../polymer/polymer-element.html">
 <link rel="import" href="../utility/completion-status-mixin.html">
 <link rel="import" href="../../d2l-icons/d2l-icon.html">
 <link rel="import" href="../../d2l-colors/d2l-colors.html">
 <link rel="import" href="../../d2l-icons/tier1-icons.html">
-<link rel="import" href="../localize-behavior.html">
 
 <dom-module id="d2l-completion-requirement">
 	<template>
@@ -31,7 +29,7 @@
 		@memberOf window.D2L.Polymer.Mixins;
 		@mixes D2L.Polymer.Mixins.CompletionStatusMixin
 		*/
-		class D2LCompletionRequirement extends Polymer.mixinBehaviors(D2L.PolymerBehaviors.SequenceNavigator.LocalizeBehavior, D2L.Polymer.Mixins.CompletionStatusMixin( Polymer.Element )) {
+		class D2LCompletionRequirement extends D2L.Polymer.Mixins.CompletionStatusMixin() {
 			static get is() {
 				return 'd2l-completion-requirement';
 			}

--- a/components/d2l-completion-status.html
+++ b/components/d2l-completion-status.html
@@ -1,9 +1,7 @@
-<link rel="import" href="../../polymer/polymer-element.html">
 <link rel="import" href="../utility/completion-status-mixin.html">
 <link rel="import" href="../../d2l-icons/d2l-icon.html">
 <link rel="import" href="../../d2l-colors/d2l-colors.html">
 <link rel="import" href="../../d2l-icons/tier1-icons.html">
-<link rel="import" href="../localize-behavior.html">
 
 <dom-module id="d2l-completion-status">
 	<template>
@@ -21,7 +19,7 @@
 		@memberOf window.D2L.Polymer.Mixins;
 		@mixes D2L.Polymer.Mixins.CompletionStatusMixin
 		*/
-		class D2LCompletionStatus extends Polymer.mixinBehaviors(D2L.PolymerBehaviors.SequenceNavigator.LocalizeBehavior, D2L.Polymer.Mixins.CompletionStatusMixin( Polymer.Element )) {
+		class D2LCompletionStatus extends D2L.Polymer.Mixins.CompletionStatusMixin() {
 			static get is() {
 				return 'd2l-completion-status';
 			}

--- a/components/d2l-lesson-header.html
+++ b/components/d2l-lesson-header.html
@@ -3,7 +3,6 @@
 <link rel="import" href="../../d2l-colors/d2l-colors.html">
 <link rel="import" href="../../d2l-offscreen/d2l-offscreen.html">
 <link rel="import" href="../../d2l-typography/d2l-typography.html">
-<link rel="import" href="../localize-behavior.html">
 <!--
 'd2l-lesson-header'
 
@@ -63,7 +62,7 @@
 		@memberOf D2L.Polymer.Mixins;
 		@mixes CompletionStatusMixin
 		*/
-		class D2LLessonHeader extends Polymer.mixinBehaviors(D2L.PolymerBehaviors.SequenceNavigator.LocalizeBehavior, D2L.Polymer.Mixins.CompletionStatusMixin(Polymer.Element)) {
+		class D2LLessonHeader extends D2L.Polymer.Mixins.CompletionStatusMixin() {
 			static get is() {
 				return 'd2l-lesson-header';
 			}

--- a/components/d2l-module-link.html
+++ b/components/d2l-module-link.html
@@ -5,7 +5,7 @@
 <link rel="import" href="../../d2l-icons/d2l-icons.html">
 <link rel="import" href="../../d2l-offscreen/d2l-offscreen.html">
 <link rel="import" href="../../d2l-typography/d2l-typography.html">
-<link rel="import" href="../localize-behavior.html">
+
 <dom-module id="d2l-module-link">
 	<template>
 		<style>
@@ -187,7 +187,7 @@
 		@memberOf window.D2L.Polymer.Mixins;
 		@mixes D2L.Polymer.Mixins.CompletionStatusMixin
 		*/
-		class D2LModuleLink extends Polymer.mixinBehaviors(D2L.PolymerBehaviors.SequenceNavigator.LocalizeBehavior, D2L.Polymer.Mixins.CompletionStatusMixin(Polymer.Element)) {
+		class D2LModuleLink extends D2L.Polymer.Mixins.CompletionStatusMixin() {
 			static get is() {
 				return 'd2l-module-link';
 			}
@@ -290,8 +290,8 @@
 			}
 
 			getSubEntities(entity) {
-				return entity.getSubEntities()
-					.filter( subEntity => this._hasClass(subEntity, 'sequenced-activity') || subEntity.href )
+				return entity && entity.getSubEntities()
+					.filter( subEntity => subEntity.hasClass('sequenced-activity') || subEntity.href )
 					.map(this._getHref);
 			}
 
@@ -300,12 +300,12 @@
 			}
 
 			_hasChildren(entity) {
-				return entity.getSubEntities().length !== 0;
+				return entity && entity.getSubEntities().length !== 0;
 			}
 
 			toggleSelected() {
 				this.selectedModule = (this.selectedModule === '') ?
-					this._getLinkByRel(this.entity, 'self').href :
+					this.entity.getLinkByRel('self').href :
 					'';
 			}
 
@@ -314,7 +314,7 @@
 			}
 
 			_getIsSelected(selectedModule) {
-				var selected = this.entity && this._getLinkByRel(this.entity, 'self').href === selectedModule;
+				var selected = this.entity && this.entity.getLinkByRel('self').href === selectedModule;
 				return (selected) ? 'selected' : 'not-selected';
 			}
 
@@ -332,7 +332,8 @@
 					return;
 				}
 				// Filter is for our demo data having sequence in the class of the subentity
-				const children = this.entity.getSubEntities().filter( subEntity => subEntity.class.includes('sequenced-activity'));
+				const children = this.entity &&
+					this.entity.getSubEntities().filter( subEntity => subEntity.class.includes('sequenced-activity'));
 				for ( let i = 0; i < children.length; i++ ) {
 					// Doing this because our demo data structure was made without embedded sub entities
 					var childLink =  children[i].href ? children[i].href : children[i].getLinkByRel('self').href;

--- a/components/d2l-sequence-navigator-item.html
+++ b/components/d2l-sequence-navigator-item.html
@@ -1,4 +1,5 @@
-<link rel="import" href="../../polymer-siren-mixins/siren-entity-mixin.html">
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../../d2l-polymer-siren-behaviors/store/entity-behavior.html">
 <link rel="import" href="d2l-module-link.html">
 <link rel="import" href="d2l-activity-link.html">
 <link rel="import" href="../../d2l-colors/d2l-colors.html">
@@ -59,7 +60,11 @@
 		@memberOf D2L.Polymer.Mixins;
 		@mixes SirenEntityMixin
 		*/
-		class D2LSequenceNavigatorItem extends D2L.Polymer.Mixins.SirenEntityMixin( Polymer.Element ) {
+		class D2LSequenceNavigatorItem extends Polymer.mixinBehaviors([
+			D2L.PolymerBehaviors.Siren.EntityBehavior
+		],
+		Polymer.Element
+		) {
 			static get is() {
 				return 'd2l-sequence-navigator-item';
 			}
@@ -103,15 +108,15 @@
 			}
 
 			getHref( entity ) {
-				return entity.getLinkByRel('self').href;
+				return entity && entity.getLinkByRel('self').href || '';
 			}
 
 			_isModule( entity ) {
-				return entity && entity.class[1] === 'sequence-description';
+				return entity && entity.hasClass('sequence-description');
 			}
 
 			_isActivity( entity ) {
-				return entity && this._hasClass(entity, 'sequenced-activity');
+				return entity && entity.hasClass('sequenced-activity');
 			}
 
 			_isStandaloneActivity( entity ) {

--- a/d2l-sequence-navigator.html
+++ b/d2l-sequence-navigator.html
@@ -117,6 +117,11 @@
 			}
 			static get properties() {
 				return {
+					href: {
+						type: String,
+						reflectToAttribute: true,
+						notify: true
+					},
 					selectedModule: {
 						type: String,
 						value: ''

--- a/d2l-sequence-navigator.html
+++ b/d2l-sequence-navigator.html
@@ -1,5 +1,5 @@
-<link rel="import" href="../../polymer/polymer.html">
-<link rel="import" href="../../d2l-polymer-siren-behaviors/store/entity-behavior.html">
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../d2l-polymer-siren-behaviors/store/entity-behavior.html">
 <link rel="import" href="./components/d2l-sequence-navigator-item.html">
 <link rel="import" href="./components/d2l-lesson-header.html">
 <link rel="import" href="../d2l-accordion/d2l-accordion.html">

--- a/d2l-sequence-navigator.html
+++ b/d2l-sequence-navigator.html
@@ -1,4 +1,5 @@
-<link rel="import" href="../polymer-siren-mixins/siren-entity-mixin.html">
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../../d2l-polymer-siren-behaviors/store/entity-behavior.html">
 <link rel="import" href="./components/d2l-sequence-navigator-item.html">
 <link rel="import" href="./components/d2l-lesson-header.html">
 <link rel="import" href="../d2l-accordion/d2l-accordion.html">
@@ -105,7 +106,12 @@
 		@memberOf D2L.Polymer.Mixins;
 		@mixes SirenEntityMixin
 		*/
-		class D2LSequenceNavigator extends Polymer.mixinBehaviors(D2L.PolymerBehaviors.SequenceNavigator.LocalizeBehavior, D2L.Polymer.Mixins.SirenEntityMixin( Polymer.Element )) {
+		class D2LSequenceNavigator extends Polymer.mixinBehaviors([
+			D2L.PolymerBehaviors.Siren.EntityBehavior,
+			D2L.PolymerBehaviors.SequenceNavigator.LocalizeBehavior
+		],
+		Polymer.Element
+		) {
 			static get is() {
 				return 'd2l-sequence-navigator';
 			}
@@ -141,20 +147,20 @@
 			}
 
 			_getModuleHref(entity) {
-				if (entity && this._hasClass( entity, 'sequence-description') ) {
-					var selfLink = this._getLinkByRel( entity, 'self' );
+				if (entity && entity.hasClass('sequence-description') ) {
+					var selfLink = entity.getLinkByRel('self');
 					return selfLink && selfLink.href || '';
 				}
-				return entity && this._hasClass(entity, 'sequenced-activity') && this._getDirectParentHref( entity ) || '';
+				return entity && entity.hasClass('sequenced-activity') && this._getDirectParentHref( entity ) || '';
 			}
 
 			_getDirectParentHref(entity) {
-				const upLink = this._getLinkByRel( entity, 'up' );
+				const upLink = entity && entity.getLinkByRel('up');
 				return upLink && upLink.href || '';
 			}
 
 			getSubEntities(entity) {
-				return entity.getSubEntities()
+				return entity && entity.getSubEntities()
 					.filter( subEntity =>
 						(subEntity.properties && Object.keys(subEntity.properties).length > 0) || subEntity.href )
 					.map(this._getHref);

--- a/utility/completion-status-mixin.html
+++ b/utility/completion-status-mixin.html
@@ -1,4 +1,6 @@
-<link rel="import" href="../../polymer-siren-mixins/siren-entity-mixin.html">
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../../d2l-polymer-siren-behaviors/store/entity-behavior.html">
+<link rel="import" href="../localize-behavior.html">
 
 <script>
 (function() {
@@ -7,9 +9,13 @@
 		@mixes SirenEntityMixin
 		@memberOf D2L.Polymer.Mixins;
 	*/
-	D2L.Polymer.Mixins.CompletionStatusMixin = function(superClass) {
-		return class extends window.D2L.Polymer.Mixins.SirenEntityMixin(superClass) {
-
+	const CompletionStatusMixin = function() {
+		return class extends Polymer.mixinBehaviors([
+			D2L.PolymerBehaviors.Siren.EntityBehavior,
+			D2L.PolymerBehaviors.SequenceNavigator.LocalizeBehavior
+		],
+		Polymer.Element
+		) {
 			static get properties() {
 				return {
 					completionCount: {
@@ -35,7 +41,7 @@
 			}
 
 			_getStatus(entity) {
-				const completionEntity = entity.getSubEntityByClass('completion');
+				const completionEntity = entity && entity.getSubEntityByClass('completion');
 				if ( !completionEntity || !completionEntity.properties) {
 					return {
 						completed: 0,
@@ -60,6 +66,9 @@
 			}
 
 			_getCompletionRequirement(activity) {
+				if (!activity) {
+					return;
+				}
 				var subEntity = activity.getSubEntityByClass('link-activity') || activity.getSubEntityByClass('file-activity');
 				if (subEntity
 					&& subEntity.getSubEntityByClass('exemption')
@@ -73,25 +82,31 @@
 			}
 
 			_getCompletionStatus(activity) {
-				var subEntity = activity.getSubEntityByClass('link-activity') || activity.getSubEntityByClass('file-activity');
-				if (subEntity && subEntity.getSubEntityByClass('completion')) {
-					if (subEntity.getSubEntityByClass('completion').hasClass('completed')) {
-						return 'complete';
-					} else {
-						return 'incomplete';
-					}
-				} else {
-					if (subEntity.getSubEntityByClass('last-viewed') ) {
+				if (!activity) {
+					return;
+				}
+				const subEntity = activity.getSubEntityByClass('link-activity') || activity.getSubEntityByClass('file-activity');
+				if (!subEntity) {
+					return;
+				}
+
+				const completionClass = subEntity.getSubEntityByClass('completion');
+				if (!completionClass) {
+					if (subEntity.getSubEntityByClass('last-viewed')) {
 						return 'optional-viewed';
 					}
 					return 'optional';
 				}
+
+				return completionClass.hasClass('completed')
+					? 'complete'
+					: 'incomplete';
 			}
 		};
 	};
 	window.D2L = window.D2L || {};
 	window.D2L.Polymer = window.D2L.Polymer || {};
 	window.D2L.Polymer.Mixins = window.D2L.Polymer.Mixins || {};
-	window.D2L.Polymer.Mixins.CompletionStatusMixin = D2L.Polymer.Mixins.CompletionStatusMixin;
+	window.D2L.Polymer.Mixins.CompletionStatusMixin = CompletionStatusMixin;
 })();
 </script>


### PR DESCRIPTION
- Add a slew of null checks
- Use entity methods (like getLinkByRel) instead of mixin methods (this._getLinkByRel)