### PR TITLE
fix accessibility issues found in testing

### DIFF
--- a/components/d2l-lesson-header.html
+++ b/components/d2l-lesson-header.html
@@ -54,7 +54,7 @@
 			<div class="module-title">[[entity.properties.title]]</div>
 			<d2l-progress-bar percent-completed=[[percentCompleted]] aria-hidden="true"></d2l-progress-bar>
 			<div class="module-completion-count" aria-hidden="true">[[localize('modulesDone', 'completed', completionCompleted, 'total', completionTotal)]]</div>
-			<d2l-offscreen>[[localize('requirementsCompleted', 'completed', completionCompleted, 'total', completionTotal)]]</d2l-offscreen>
+			<div><d2l-offscreen>[[localize('requirementsCompleted', 'completed', completionCompleted, 'total', completionTotal)]]</d2l-offscreen></div>
 		</div>
 
 	</template>

--- a/components/d2l-module-link.html
+++ b/components/d2l-module-link.html
@@ -95,13 +95,13 @@
 				letter-spacing: 0.2px;
 			}
 
-			d2l-sequence-navigator-item:not(.current):not(:hover) {
+			.nav-item:not(.current):not(:hover) {
 				border: 1px solid var(--d2l-color-mica);
 				background-color: white;
 			}
 
-			d2l-sequence-navigator-item.current,
-			d2l-sequence-navigator-item:hover {
+			.nav-item.current,
+			.nav-item:hover {
 				background-color: #f2f8fc;
 				border: 1px solid #99c5e5;
 				border-bottom: 1px solid #99c5e5;
@@ -109,7 +109,7 @@
 				z-index: 0.5;
 			}
 
-			li:last-of-type > d2l-sequence-navigator-item {
+			li:last-of-type > .nav-item {
 				border-radius: 0px 1px 8px 8px;
 			}
 
@@ -164,7 +164,7 @@
 			<ol class="module-item-list">
 				<template is="dom-repeat" items="[[subEntities]]" as="childLink">
 					<li on-click="_onActivityClicked">
-						<d2l-sequence-navigator-item  class$="[[_getIsCurrent(childLink, currentActivity)]]"
+						<d2l-sequence-navigator-item class$="nav-item [[_getIsCurrent(childLink, currentActivity)]]"
 							href="[[childLink.href]]"
 							token="[[token]]"
 							current-activity="{{currentActivity}}"


### PR DESCRIPTION
Issue 1: Selecting on any topic regardless of which module it is in, makes the lines separating the topics disappear (Firefox issue)

Fix 1: In the CSS rule, target by class instead

Issue 2: Lesson header lang term is reporting the wrong numbers (Firefox issue)

Fix 2: surround <d2l-offscreen> tags with <div>tags so that it's not read immediately after the previous text