### PR TITLE
Removing d2l icon when activity has no icon

### DIFF
--- a/components/d2l-activity-link.html
+++ b/components/d2l-activity-link.html
@@ -63,7 +63,9 @@
 
 		</style>
 		<div>
-			<d2l-icon icon="[[_getIconSetKey(entity)]]"></d2l-icon>
+			<template is="dom-if" if="[[hasIcon]]">
+				<d2l-icon icon="[[_getIconSetKey(entity)]]"></d2l-icon>
+			</template>
 			<a on-click="setCurrent" class$="[[completionRequirement]]">
 				[[entity.properties.title]]
 			</a>
@@ -105,6 +107,11 @@
 					showCompletionRequirement: {
 						type: Boolean,
 						value: false
+					},
+					hasIcon: {
+						type: Boolean,
+						value: false,
+						computed: '_hasIcon(entity)'
 					}
 				};
 			}
@@ -135,13 +142,14 @@
 					this.dispatchEvent( new CustomEvent('activitySelected', { detail:{ activityHref: currentActivity }, composed: true } ) );
 				}
 			}
+
+			_hasIcon(entity) {
+				var tierClass = 'tier1';
+				return entity && entity.getSubEntityByClass(tierClass);
+			}
+
 			_getIconSetKey(entity) {
 				var tierClass = 'tier1';
-
-				if (!entity || !entity.getSubEntityByClass(tierClass)) {
-					return 'd2l-tier1:help';
-				}
-		
 				return (entity.getSubEntityByClass(tierClass)).properties.iconSetKey;
 			}
 

--- a/test/d2l-activity-link.html
+++ b/test/d2l-activity-link.html
@@ -126,10 +126,9 @@
 						element = await SirenFixture.load('data/activity3.json', fixture('ActivityWithIconTestFixture'));
 					});
 
-					it('should have the default icon', ()=> {
+					it('should not have a d2l-icon element', ()=> {
 						const el = element.shadowRoot.querySelector('d2l-icon');
-						expect(el).to.have.attribute('icon');
-						expect(el).attribute('icon').to.equal('d2l-tier1:help');
+						expect(el).not.to.exist;
 					});
 				});
 			});

--- a/test/d2l-activity-link.html
+++ b/test/d2l-activity-link.html
@@ -40,6 +40,12 @@
 			</template>
 		</test-fixture>
 
+		<test-fixture id="ActivityWithoutIconTestFixture">
+				<template>
+					<d2l-activity-link href="data/activity3.json" token="bamboozle"></d2l-activity-link>
+				</template>
+			</test-fixture>
+
 		<test-fixture id="basic">
 			<template>
 				<d2l-activity-link href="data/unit2-activity1.json" token="bamboozle" current-activity="an-activity"></d2l-activity-link>
@@ -123,7 +129,7 @@
 				describe('for an activity that does not have an icon', ()=>{
 					let element;
 					beforeEach(async() => {
-						element = await SirenFixture.load('data/activity3.json', fixture('ActivityWithIconTestFixture'));
+						element = await SirenFixture.load('data/activity3.json', fixture('ActivityWithoutIconTestFixture'));
 					});
 
 					it('should not have a d2l-icon element', ()=> {


### PR DESCRIPTION
Rally: https://rally1.rallydev.com/#/15545269080ud/detail/task/263279267048

Don't stamp out d2l-icon if the entity has no icon