### PR TITLE
Fixing released activities being added the navigator with an incorrect completion status

### DIFF
--- a/components/d2l-completion-requirement.html
+++ b/components/d2l-completion-requirement.html
@@ -40,18 +40,12 @@
 						observer: '_showCompletionRequirementType'
 					},
 					isExempt: {
-						type: Boolean,
-						value: false
+						type: Boolean
 					},
 					isOptional: {
-						type: Boolean,
-						value: false
+						type: Boolean
 					}
 				};
-			}
-
-			connectedCallback() {
-				super.connectedCallback();
 			}
 
 			_showCompletionRequirementType( exemption ) {
@@ -62,6 +56,9 @@
 					case 'optional':
 						this.isOptional = true;
 						break;
+					default:
+						this.isExempt = false;
+						this.isOptional = false;
 				}
 			}
 		}

--- a/components/d2l-completion-status.html
+++ b/components/d2l-completion-status.html
@@ -31,18 +31,12 @@
 						observer: '_showCompletionType'
 					},
 					isOptional: {
-						type: Boolean,
-						value: false
+						type: Boolean
 					},
 					isComplete: {
-						type: Boolean,
-						value: false
+						type: Boolean
 					}
 				};
-			}
-
-			connectedCallback() {
-				super.connectedCallback();
 			}
 
 			_showCompletionType( completion ) {
@@ -57,6 +51,9 @@
 					case 'optional':
 						this.isOptional = true;
 						break;
+					case 'incomplete':
+						this.isComplete = false;
+						this.isOptional = false;
 				}
 			}
 		}


### PR DESCRIPTION
This fixes the issue of a new activity being added to the navigator with a completed check mark and a completion requirement, that is not related to the new activity.