### PR TITLE
[NAV] End of lesson link should be keyboard accessible

### DIFF
--- a/components/d2l-sequence-end.html
+++ b/components/d2l-sequence-end.html
@@ -59,12 +59,26 @@
 					}
 				};
 			}
+
+			ready() {
+				super.ready();
+				this.addEventListener('keypress', this._onKeyPress);
+			}
+
 			_getContainerClass(currentActivity) {
 				if (this.href === currentActivity) {
 					return 'd2l-asv-current';
 				}
 				return '';
 			}
+
+			_onKeyPress(event) {
+				if ( event.key !== 'Enter' ) {
+					return;
+				}
+				this.showEndOfLesson();
+			}
+
 			showEndOfLesson() {
 				this.currentActivity = this.href;
 			}


### PR DESCRIPTION
When the End of Lesson link has focus, it should listen to the `enter` keystroke to be viewed.