### PR TITLE
Allow disabling of d2l outer modules

### DIFF
--- a/components/d2l-outer-module.html
+++ b/components/d2l-outer-module.html
@@ -180,8 +180,20 @@
 						type: Boolean,
 						value: false,
 						computed: '_showOptional(completionCount)'
+					},
+					disabled: {
+						type: Boolean,
+						observer: '_disableAccordions'
 					}
 				};
+			}
+
+			_disableAccordions(disabled) {
+				if ( !disabled || !this.shadowRoot || !this.shadowRoot.querySelector('d2l-accordion-collapse') ) {
+					return;
+				}
+				this.shadowRoot.querySelector('d2l-accordion-collapse').setAttribute('opened', '');
+				this.shadowRoot.querySelector('d2l-accordion-collapse').setAttribute('disabled', '');
 			}
 
 			_isAccordionOpen() {

--- a/d2l-sequence-navigator.html
+++ b/d2l-sequence-navigator.html
@@ -61,6 +61,7 @@
 								href="[[childLink.href]]"
 								token="[[token]]"
 								current-activity="{{href}}"
+								disabled="[[disabled]]"
 							></d2l-outer-module>
 						</template>						
 						<template is="dom-if" if="[[_isActivity(childLink)]]">
@@ -111,9 +112,13 @@
 					sidebarContent: {
 						type: Object,
 						computed: 'getSideBarContent()'
+					},
+					disabled: {
+						type: Boolean
 					}
 				};
 			}
+
 			ready() {
 				super.ready();
 				const styles = JSON.parse(document.getElementsByTagName('html')[0].getAttribute('data-asv-css-vars'));

--- a/test/d2l-outer-module.html
+++ b/test/d2l-outer-module.html
@@ -32,6 +32,12 @@
 				<d2l-outer-module token="bamboozle"></d2l-outer-module>
 			</template>
 		</test-fixture>
+
+		<test-fixture id="DisabledModuleWithChildrenFixture">
+			<template>
+				<d2l-outer-module token="bamboozle" disabled></d2l-outer-module>
+			</template>
+		</test-fixture>
 		<script>
 			/* global SirenFixture */
 			describe('d2l-outer-module', () => {
@@ -353,6 +359,44 @@
 							expect(optionalStatus).to.be.hidden;
 
 							expect(checkmark).to.be.hidden;
+						});
+					});
+				});
+
+				describe('for module with the disabled attribute', () => {
+
+					let element;
+
+					beforeEach(async() => {
+						element = await SirenFixture.load('data/lesson1.json', fixture('DisabledModuleWithChildrenFixture'));
+					});
+
+					it('should have the d2l-accordion-collapse elements opened and disabled, regardless of clicked', () => {
+						const accordionElement = element.shadowRoot.querySelector('d2l-accordion-collapse');
+						accordionElement.addEventListener('click', () => {
+							const dynamicElements = accordionElement.shadowRoot.querySelectorAll('dom-if');
+							if (dynamicElements) {
+								for (let i = 0; i < dynamicElements.length; i++) {
+									dynamicElements[i].render();
+								}
+							}
+						});
+
+						flush(() => {
+							expect(accordionElement.opened).to.be.true;
+							expect(accordionElement.disabled).to.be.true;
+
+							accordionElement.$.trigger.click();
+							expect(accordionElement.opened).to.be.true;
+							expect(accordionElement.disabled).to.be.true;
+
+							accordionElement.$.trigger.click();
+							expect(accordionElement.opened).to.be.true;
+							expect(accordionElement.disabled).to.be.true;
+
+							accordionElement.$.trigger.click();
+							expect(accordionElement.opened).to.be.true;
+							expect(accordionElement.disabled).to.be.true;
 						});
 					});
 				});


### PR DESCRIPTION
We want the ability to disable the d2l-outer-modules for use in the d2l-sequence-launcher.