### PR TITLE
add completion count component (right now for the launcher, but we

### DIFF
--- a/components/d2l-module-completion-count.html
+++ b/components/d2l-module-completion-count.html
@@ -1,0 +1,22 @@
+<link rel="import" href="../utility/completion-status-mixin.html">
+<dom-module id="d2l-module-completion-count">
+	<template>
+		<style>
+		</style>
+		<span class="countStatus" aria-hidden="true">
+			[[localize('countStatus', 'completed', completionCompleted, 'total', completionTotal)]]
+		</span>
+		<d2l-offscreen>[[localize('requirementsCompleted', 'completed', completionCompleted, 'total', completionTotal)]]</d2l-offscreen>
+	</template>
+	<script>
+		class D2LModuleCompletionCount extends D2L.Polymer.Mixins.CompletionStatusMixin() {
+			static get is() {
+				return 'd2l-module-completion-count';
+			}
+			static get properties() {
+			}
+		}
+		window.customElements.define(D2LModuleCompletionCount.is, D2LModuleCompletionCount);
+	</script>
+
+</dom-module>


### PR DESCRIPTION
should switch to using it in the navigator too)

This is to support the launcher displaying completion counts. 
Progress completion should be "Completed 2/7" to be consistent with immersive ASV view
