### PR TITLE
add keyup listener to collapse

### DIFF
--- a/components/d2l-module-completion-count.html
+++ b/components/d2l-module-completion-count.html
@@ -1,0 +1,22 @@
+<link rel="import" href="../utility/completion-status-mixin.html">
+<dom-module id="d2l-module-completion-count">
+	<template>
+		<style>
+		</style>
+		<span class="countStatus" aria-hidden="true">
+			[[localize('countStatus', 'completed', completionCompleted, 'total', completionTotal)]]
+		</span>
+		<d2l-offscreen>[[localize('requirementsCompleted', 'completed', completionCompleted, 'total', completionTotal)]]</d2l-offscreen>
+	</template>
+	<script>
+		class D2LModuleCompletionCount extends D2L.Polymer.Mixins.CompletionStatusMixin() {
+			static get is() {
+				return 'd2l-module-completion-count';
+			}
+			static get properties() {
+			}
+		}
+		window.customElements.define(D2LModuleCompletionCount.is, D2LModuleCompletionCount);
+	</script>
+
+</dom-module>

--- a/components/d2l-module-completion-count.html
+++ b/components/d2l-module-completion-count.html
@@ -4,7 +4,7 @@
 		<style>
 		</style>
 		<span class="countStatus" aria-hidden="true">
-			[[localize('countStatus', 'completed', completionCompleted, 'total', completionTotal)]]
+				[[localize('completedMofN', 'completed', completionCompleted, 'total', completionTotal)]]
 		</span>
 		<d2l-offscreen>[[localize('requirementsCompleted', 'completed', completionCompleted, 'total', completionTotal)]]</d2l-offscreen>
 	</template>

--- a/components/d2l-outer-module.html
+++ b/components/d2l-outer-module.html
@@ -98,6 +98,8 @@
 		<d2l-accordion-collapse
 			no-icons
 			flex
+			id="collapse"
+			on-keydown="_keyDownListener"
 		>
 			<div slot="header" id="header-container" class$="[[_getIsSelected(currentActivity)]]" on-click="_onHeaderClicked">
 				<div class="module-header">
@@ -196,6 +198,12 @@
 						type: Boolean
 					}
 				};
+			}
+
+			_keyDownListener(event) {
+				if (event.keyCode === 13) {
+					this._contentObjectClick();
+				}
 			}
 
 			_disableAccordions(disabled) {

--- a/components/d2l-outer-module.html
+++ b/components/d2l-outer-module.html
@@ -98,7 +98,6 @@
 		<d2l-accordion-collapse
 			no-icons
 			flex
-			id="collapse"
 			on-keydown="_keyDownListener"
 		>
 			<div slot="header" id="header-container" class$="[[_getIsSelected(currentActivity)]]" on-click="_onHeaderClicked">

--- a/components/d2l-outer-module.html
+++ b/components/d2l-outer-module.html
@@ -98,7 +98,7 @@
 		<d2l-accordion-collapse
 			no-icons
 			flex
-			on-keydown="_keyDownListener"
+			on-keyup="_keyUpListener"
 		>
 			<div slot="header" id="header-container" class$="[[_getIsSelected(currentActivity)]]" on-click="_onHeaderClicked">
 				<div class="module-header">
@@ -199,7 +199,7 @@
 				};
 			}
 
-			_keyDownListener(event) {
+			_keyUpListener(event) {
 				if (event.keyCode === 13) {
 					this._contentObjectClick();
 				}


### PR DESCRIPTION
Use the keydown event on accordion-collapse to navigate the user using tabs and enter. 