### PR TITLE
focus styling should work correctly now

### DIFF
--- a/components/d2l-lesson-header.html
+++ b/components/d2l-lesson-header.html
@@ -29,7 +29,7 @@
 			border-radius: 8px 0px 0px 8px;
 		}
 
-		:host(.d2l-asv-current){
+		:host(.d2l-asv-current) {
 			--d2l-lesson-header-background-color: var(--d2l-asv-primary-color);
 			--d2l-lesson-header-text-color: var(--d2l-asv-selected-text-color);
 			--d2l-lesson-header-border-color: var(--d2l-asv-border-color);

--- a/components/d2l-outer-module.html
+++ b/components/d2l-outer-module.html
@@ -29,18 +29,17 @@
 				border-style: solid;
 				border-width: var(--d2l-outer-module-border-width, 2px 0px 2px 0);
 				border-color:  var(--d2l-outer-module-border-color);
-				
 			}
 
-			#header-container:focus-within {
-				background-color: var(--d2l-asv-hover-color);
+			d2l-accordion-collapse:focus-within {
+				--d2l-outer-module-background-color: var(--d2l-asv-hover-color);
 				--d2l-outer-module-border-color: var(--d2l-asv-border-color);
 				--d2l-outer-module-text-color: var(--d2l-asv-text-color);
+				outline: none;
 			}
 
-			#header-container:focus,
 			#header-container:hover {
-				background-color: var(--d2l-asv-hover-color);
+				--d2l-outer-module-background-color: var(--d2l-asv-hover-color);
 				--d2l-outer-module-border-color: var(--d2l-asv-border-color);
 				--d2l-outer-module-text-color: var(--d2l-asv-text-color);
 			}


### PR DESCRIPTION
I use css variables and rules that apply to the d2l-accordion-collapse to style the header element when we have focus.  I still haven't gotten rid of the link outline though.