### PR TITLE
US109295 Fix initial and swiching topics/modules meter colour

### DIFF
--- a/components/d2l-lesson-header.js
+++ b/components/d2l-lesson-header.js
@@ -298,12 +298,14 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 
 	_lightenMeter() {
 		const style = getComputedStyle(this);
-		// const bkgdColour = style.getPropertyValue('--d2l-lesson-header-background-color').trim();
+		const bkgdColour = style.getPropertyValue('--d2l-lesson-header-background-color').trim();
 		const opacity = style.getPropertyValue('--d2l-lesson-header-opacity');
-		// const ferrite = style.getPropertyValue('--d2l-color-ferrite').trim();
+		const ferrite = style.getPropertyValue('--d2l-color-ferrite').trim();
 
-		this._lightMeter = opacity >= 1 && this.currentActivity === this._selfLink;
-			// bkgdColour !== 'transparent' && !isColorAccessible(bkgdColour, ferrite) ||
+		this._lightMeter = opacity >= 1 &&
+			this.currentActivity === this._selfLink &&
+			bkgdColour !== 'transparent' &&
+			!isColorAccessible(bkgdColour, ferrite);
 	}
 
 	_getHeaderClass(currentActivity, entity, focusWithin) {

--- a/components/d2l-lesson-header.js
+++ b/components/d2l-lesson-header.js
@@ -283,7 +283,7 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 			_selfLink: {
 				type: String,
 				value: '',
-				computed: '_getSelfLink(entity',
+				computed: '_getSelfLink(entity)',
 				observer: '_lightenMeter'
 			}
 		};
@@ -298,11 +298,12 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 
 	_lightenMeter() {
 		const style = getComputedStyle(this);
-		const bkgdColour = style.getPropertyValue('--d2l-lesson-header-background-color').trim();
+		// const bkgdColour = style.getPropertyValue('--d2l-lesson-header-background-color').trim();
 		const opacity = style.getPropertyValue('--d2l-lesson-header-opacity');
-		const ferrite = style.getPropertyValue('--d2l-color-ferrite').trim();
+		// const ferrite = style.getPropertyValue('--d2l-color-ferrite').trim();
 
-		this._lightMeter = opacity >= 1 && bkgdColour !== 'transparent' && !isColorAccessible(bkgdColour, ferrite);
+		this._lightMeter = opacity >= 1 && this.currentActivity === this._selfLink;
+			// bkgdColour !== 'transparent' && !isColorAccessible(bkgdColour, ferrite) ||
 	}
 
 	_getHeaderClass(currentActivity, entity, focusWithin) {

--- a/components/d2l-lesson-header.js
+++ b/components/d2l-lesson-header.js
@@ -251,7 +251,7 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 				type: String,
 				value: '',
 				notify: true,
-				observer: '_currentActivityChanged'
+				observer: '_lightenMeter'
 			},
 			moduleProperties: Object,
 			_useModuleIndex: {
@@ -279,6 +279,12 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 			_lightMeter: {
 				type: Boolean,
 				value: false
+			},
+			_selfLink: {
+				type: String,
+				value: '',
+				computed: '_getSelfLink(entity',
+				observer: '_lightenMeter'
 			}
 		};
 	}
@@ -305,8 +311,12 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 		return this._getTrueClass(focusWithin, selected);
 	}
 
+	_getSelfLink(entity) {
+		return entity && entity.getLinkByRel('self').href || '';
+	}
+
 	_onHeaderClicked() {
-		this.currentActivity = this.entity && this.entity.getLinkByRel('self').href || '';
+		this.currentActivity = this._selfLink;
 	}
 	isLightTheme() {
 		var styles = JSON.parse(document.getElementsByTagName('html')[0].getAttribute('data-asv-css-vars'));
@@ -334,10 +344,6 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 
 	_getUseNewProgressBar(moduleProperties) {
 		return moduleProperties && moduleProperties.useNewProgressBar;
-	}
-
-	_currentActivityChanged(currentActivity) {
-		this._lightenMeter();
 	}
 }
 

--- a/components/d2l-lesson-header.js
+++ b/components/d2l-lesson-header.js
@@ -250,7 +250,8 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 			currentActivity: {
 				type: String,
 				value: '',
-				notify: true
+				notify: true,
+				observer: '_currentActivityChanged'
 			},
 			moduleProperties: Object,
 			_useModuleIndex: {
@@ -287,7 +288,6 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 		this.addEventListener('mouseover', this._lightenMeter);
 		this.addEventListener('mouseout', this._lightenMeter);
 		this.addEventListener('blur', this._lightenMeter);
-		this._lightenMeter();
 	}
 
 	_lightenMeter() {
@@ -334,6 +334,10 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 
 	_getUseNewProgressBar(moduleProperties) {
 		return moduleProperties && moduleProperties.useNewProgressBar;
+	}
+
+	_currentActivityChanged(currentActivity) {
+		this._lightenMeter();
 	}
 }
 

--- a/test/d2l-lesson-header.html
+++ b/test/d2l-lesson-header.html
@@ -12,7 +12,15 @@
 		<script src="../node_modules/polymer-siren-test-helpers/dist/index.js"></script>
 		<script type="module" src="../../@polymer/polymer/polymer-legacy.js"></script>
 		<script type="module" src="../components/d2l-lesson-header.js"></script>
+		<style>
+			#DarkBackgroundFixture {
+				--d2l-asv-primary-color: #990000;
 
+			}
+			#LightBackgroundFixture {
+				--d2l-asv-primary-color: #6ffaff;
+			}
+		</style>
 	</head>
 	<body>
 		<test-fixture id="LessonFixture">
@@ -24,6 +32,22 @@
 		<test-fixture id="BadLessonFixture">
 			<template>
 				<d2l-lesson-header token="bamboozle"></d2l-lesson-header>
+			</template>
+		</test-fixture>
+		<test-fixture id="DarkBackgroundFixture">
+			<template>
+				<d2l-lesson-header  token="bamboozle"
+									current-activity="data/lesson1.json"
+									module-properties='{"useNewProgressBar":true}'>
+				</d2l-lesson-header>
+			</template>
+		</test-fixture>
+		<test-fixture id="LightBackgroundFixture">
+			<template>
+				<d2l-lesson-header  token="bamboozle"
+									current-activity="data/lesson1.json"
+									module-properties='{"useNewProgressBar":true}'>
+ 				</d2l-lesson-header>
 			</template>
 		</test-fixture>
 		<script type="module">
@@ -109,6 +133,44 @@ describe('d2l-lesson-header', () => {
 			expect( completionCount )
 				.to.contain
 				.text('Completed 0/0');
+		});
+	});
+
+	describe('dark background meter behaviour', () => {
+		let element;
+
+		beforeEach(async() => {
+			element = await SirenFixture('data/lesson1.json', fixture('DarkBackgroundFixture'));
+		});
+
+		it('should lighten the meter when selected and not hovered over', (done) => {
+			element.classList.add('d2l-asv-current');
+			flush(() => {
+				const meter = element.shadowRoot.querySelector('d2l-meter-circle');
+				expect(meter.hasAttribute('foreground-light'))
+					.to
+					.equal(true);
+				done();
+			});
+		});
+	});
+
+	describe('light background meter behaviour', () => {
+		let element;
+
+		beforeEach(async() => {
+			element = await SirenFixture('data/lesson1.json', fixture('LightBackgroundFixture'));
+		});
+
+		it('should not lighten the meter when selected and not hovered over', (done) => {
+			element.classList.add('d2l-asv-current');
+			flush(() => {
+				const meter = element.shadowRoot.querySelector('d2l-meter-circle');
+				expect(meter.hasAttribute('foreground-light'))
+					.to
+					.equal(false);
+				done();
+			});
 		});
 	});
 });


### PR DESCRIPTION
[Rally story](https://rally1.rallydev.com/#/289692574792/detail/userstory/328282569260)

This fixes both these defects:
- Initial meter colour being dark on a dark background
- Meter colour not changing back to dark when clicking off the lesson header to a different module/topic