### PR TITLE
DE36022: Content Topics with a title with 36 characters or more cause the side nav not to close

### DIFF
--- a/components/d2l-lesson-header.js
+++ b/components/d2l-lesson-header.js
@@ -26,12 +26,13 @@ import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 	static get template() {
 		return html`
-		<style>
+		<style>		
 		:host {
 			--d2l-lesson-header-text-color: var(--d2l-asv-text-color);
 			--d2l-lesson-header-background-color: transparent;
 			--d2l-lesson-header-border-color: transparent;
 			--d2l-lesson-header-opacity: 1;
+			--d2l-meter-size: 48px;
 			background-color: transparent;
 			color: var(--d2l-lesson-header-text-color);
 			margin: 10px var(--d2l-sequence-nav-padding) 10px var(--d2l-sequence-nav-padding);
@@ -39,7 +40,6 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 			display: block;
 			position: relative;
 			z-index: 0;
-
 		}
 
 		:host(.d2l-asv-current) {
@@ -87,15 +87,13 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 		.module-title {
 			@apply --d2l-heading-3;
 			font-size: 24px;
-
 			overflow: hidden;
+			word-wrap: break-word;
 			text-overflow: ellipsis;
-
 			display: -webkit-box;
 			-webkit-box-orient: vertical;
 			-webkit-line-clamp: 2; /* number of lines to show */
 			max-height: 3rem; /* fallback */
-
 			margin-top: 0px;
 			margin-bottom: 0px;
 		}
@@ -187,11 +185,10 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 		div.title-container {
 			display: flex;
 			justify-content: space-between;
-			align-items: flex-start;
 		}
 		d2l-meter-circle {
-			width: 48px;
-			min-width: 48px;
+			width: var(--d2l-meter-size);
+			min-width: var(--d2l-meter-size);
 		}
 
 		d2l-icon {
@@ -206,33 +203,31 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 		<div class="bkgd"></div>
 		<div class="border"></div>
 		<a href="javascript:void(0)" class="d2l-header-lesson-link" on-click="_onHeaderClicked">
-			<div>
-				<div class="title-container">
-					<div>
-						<template is="dom-if" if="[[_useModuleIndex]]">
-							<div class="unit-info">
-								<span>[[_moduleTitle]]</span>
-								<d2l-icon icon="d2l-tier1:bullet"></d2l-icon>
-								<span>[[localize('currentModule', 'current', _moduleIndex, 'total', _siblingModules)]]</span>
-							</div>
-						</template>
-						<span class="module-title">[[entity.properties.title]]</span>
-					</div>
-					<template is="dom-if" if="[[_useNewProgressBar]]">
-						<d2l-meter-circle
-							class="d2l-progress"
-							value="[[completionCount.completed]]"
-							max="[[completionCount.total]]"
-							foreground-light$="[[_lightMeter]]">
-						</d2l-meter-circle>
+			<div class="title-container">
+				<div style="width: calc(100% - var(--d2l-meter-size))">
+					<template is="dom-if" if="[[_useModuleIndex]]">
+						<div class="unit-info">
+							<span>[[_moduleTitle]]</span>
+							<d2l-icon icon="d2l-tier1:bullet"></d2l-icon>
+							<span>[[localize('currentModule', 'current', _moduleIndex, 'total', _siblingModules)]]</span>
+						</div>
 					</template>
+					<span class="module-title">[[entity.properties.title]]</span>
 				</div>
-				<template is="dom-if" if="[[!_useNewProgressBar]]">
-					<progress id$="[[isLightTheme()]]" class="d2l-progress" value="[[percentCompleted]]" max="100"></progress>
-					<div class="module-completion-count" aria-hidden="true">[[localize('completedMofN', 'completed', completionCompleted, 'total', completionTotal)]]</div>
+				<template is="dom-if" if="[[_useNewProgressBar]]">
+					<d2l-meter-circle
+						class="d2l-progress"
+						value="[[completionCount.completed]]"
+						max="[[completionCount.total]]"
+						foreground-light$="[[_lightMeter]]">
+					</d2l-meter-circle>
 				</template>
-				<div><d2l-offscreen>[[localize('requirementsCompleted', 'completed', completionCompleted, 'total', completionTotal)]]</d2l-offscreen></div>
 			</div>
+			<template is="dom-if" if="[[!_useNewProgressBar]]">
+				<progress id$="[[isLightTheme()]]" class="d2l-progress" value="[[percentCompleted]]" max="100"></progress>
+				<div class="module-completion-count" aria-hidden="true">[[localize('completedMofN', 'completed', completionCompleted, 'total', completionTotal)]]</div>
+			</template>
+			<div><d2l-offscreen>[[localize('requirementsCompleted', 'completed', completionCompleted, 'total', completionTotal)]]</d2l-offscreen></div>
 		</a>
 `;
 	}

--- a/components/d2l-lesson-header.js
+++ b/components/d2l-lesson-header.js
@@ -26,7 +26,7 @@ import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 	static get template() {
 		return html`
-		<style>		
+		<style>
 		:host {
 			--d2l-lesson-header-text-color: var(--d2l-asv-text-color);
 			--d2l-lesson-header-background-color: transparent;
@@ -186,6 +186,9 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 			display: flex;
 			justify-content: space-between;
 		}
+		div.title {
+			width: calc(100% - var(--d2l-meter-size));
+		}
 		d2l-meter-circle {
 			width: var(--d2l-meter-size);
 			min-width: var(--d2l-meter-size);
@@ -204,7 +207,7 @@ class D2LLessonHeader extends ASVFocusWithinMixin(CompletionStatusMixin()) {
 		<div class="border"></div>
 		<a href="javascript:void(0)" class="d2l-header-lesson-link" on-click="_onHeaderClicked">
 			<div class="title-container">
-				<div style="width: calc(100% - var(--d2l-meter-size))">
+				<div class="title">
 					<template is="dom-if" if="[[_useModuleIndex]]">
 						<div class="unit-info">
 							<span>[[_moduleTitle]]</span>

--- a/demo/index.html
+++ b/demo/index.html
@@ -21,12 +21,6 @@
 	<custom-style>
 		<style is="custom-style" include="demo-pages-shared-styles"></style>
 		<style>
-			.sidebar {
-				width: 330px;
-				height: 800px;
-				background: white;
-			}
-
 			html {
 				--d2l-asv-primary-color: #990000;
 				--d2l-asv-accent-color: rgb(142, 124, 195);

--- a/demo/index.html
+++ b/demo/index.html
@@ -46,7 +46,6 @@
 	</style>
 
 <body class="d2l-typography">
-
 	<div class="vertical-section-container centered">
 		<h3>Simple sequence-navigator</h3>
 		<demo-snippet>
@@ -117,7 +116,6 @@
 			</template>
 		</demo-snippet>
 	</div>
-	</script>
 </body>
 
 </html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -52,18 +52,16 @@
 		<demo-snippet>
 			<template>
 				<h4>Sequence navigator in a sidebar</h4>
-				<div class="sidebar">
-					<d2l-sequence-navigator href="data/m2-activity2.json" token="foozleberries"
-						current-activity="data/m2-activity2.json">
-						<d2l-lesson-header slot="lesson-header"
-										   href="data/lesson1.json"
-										   token="token"
-										   module-properties='{"moduleIndex":2,"numberOfSiblingModules":6,"title":"Testo Courso","useNewProgressBar":true}'>
-						</d2l-lesson-header>
-						<d2l-sequence-end slot="end-of-lesson" href="data/sequence-end.json" text="End of Sequence"
-							token="foozleberries"></d2l-sequence-end>
-					</d2l-sequence-navigator>
-				</div>
+				<d2l-sequence-navigator href="data/m2-activity2.json" token="foozleberries"
+					current-activity="data/m2-activity2.json">
+					<d2l-lesson-header slot="lesson-header"
+									   href="data/lesson1.json"
+									   token="token"
+									   module-properties='{"moduleIndex":2,"numberOfSiblingModules":6,"title":"Testo Courso","useNewProgressBar":true}'>
+					</d2l-lesson-header>
+					<d2l-sequence-end slot="end-of-lesson" href="data/sequence-end.json" text="End of Sequence"
+						token="foozleberries"></d2l-sequence-end>
+				</d2l-sequence-navigator>
 			</template>
 		</demo-snippet>
 		<demo-snippet>


### PR DESCRIPTION
- Fixes an issue where really long titles will stretch the component beyond the length defined in d2l-sequence-viewer.
- Since that parent component controls the width (and not this one), I removed some misleading demo code.

### DEPENDENCIES:

d2l-sequence-viewer: https://github.com/Brightspace/d2l-sequence-viewer/pull/217

### SCREENSHOTS:

![seq-nav](https://user-images.githubusercontent.com/14796305/65615884-b3174c80-df7f-11e9-89f6-ebcaed9c00ed.PNG)

![seq-viewer1](https://user-images.githubusercontent.com/14796305/65615678-5ddb3b00-df7f-11e9-96de-ffc05edeedc3.PNG)

![seq-viewer2](https://user-images.githubusercontent.com/14796305/65615686-62075880-df7f-11e9-9420-034dd0ebb0d0.PNG)