### PR TITLE
DE36022: Content Topics with a title with 36 characters or more cause the side nav not to close

### DIFF
--- a/components/d2l-activity-link.js
+++ b/components/d2l-activity-link.js
@@ -21,6 +21,9 @@ class D2LActivityLink extends ASVFocusWithinMixin(PolymerASVLaunchMixin(Completi
 				--d2l-activity-link-text-color: var(--d2l-asv-text-color);
 				--d2l-activity-link-opacity: 1;
 				--d2l-activity-link-backdrop-opacity: 0;
+				--d2l-left-icon-padding: 15px;
+				--d2l-right-icon-padding: 24px;
+				--d2l-icon-size: 18px;
 				display: block;
 				cursor: pointer;
 				@apply --d2l-body-compact-text;
@@ -106,8 +109,14 @@ class D2LActivityLink extends ASVFocusWithinMixin(PolymerASVLaunchMixin(Completi
 			}
 
 			.d2l-activity-link-title {
-				padding-left: 15px;
-				flex: 1 100%;
+				padding-right: var(--d2l-right-icon-padding);
+				word-wrap: break-word;
+				width: calc(
+					100% - 
+					var(--d2l-left-icon-padding) -
+					var(--d2l-right-icon-padding) -
+					(var(--d2l-icon-size) * 2)
+				);
 			}
 
 			a {
@@ -133,14 +142,12 @@ class D2LActivityLink extends ASVFocusWithinMixin(PolymerASVLaunchMixin(Completi
 			}
 
 			d2l-completion-status {
-				width: 6%;
 				color: var(--d2l-activity-link-text-color);
-				padding-left: 24px;
-				text-align: right;
 			}
 
 			d2l-icon {
 				padding-top: 3px;
+				padding-right: var(--d2l-left-icon-padding);
 				color: var(--d2l-activity-link-text-color);
 			}
 

--- a/components/d2l-activity-link.js
+++ b/components/d2l-activity-link.js
@@ -109,7 +109,6 @@ class D2LActivityLink extends ASVFocusWithinMixin(PolymerASVLaunchMixin(Completi
 			}
 
 			.d2l-activity-link-title {
-				padding-right: var(--d2l-right-icon-padding);
 				word-wrap: break-word;
 				width: calc(
 					100% - 
@@ -143,6 +142,7 @@ class D2LActivityLink extends ASVFocusWithinMixin(PolymerASVLaunchMixin(Completi
 
 			d2l-completion-status {
 				color: var(--d2l-activity-link-text-color);
+				padding-left: var(--d2l-left-icon-padding);
 			}
 
 			d2l-icon {

--- a/components/d2l-activity-link.js
+++ b/components/d2l-activity-link.js
@@ -109,6 +109,7 @@ class D2LActivityLink extends ASVFocusWithinMixin(PolymerASVLaunchMixin(Completi
 			}
 
 			.d2l-activity-link-title {
+				padding-right: var(--d2l-right-icon-padding);
 				word-wrap: break-word;
 				width: calc(
 					100% - 
@@ -141,8 +142,8 @@ class D2LActivityLink extends ASVFocusWithinMixin(PolymerASVLaunchMixin(Completi
 			}
 
 			d2l-completion-status {
+				width: var(--d2l-icon-size);
 				color: var(--d2l-activity-link-text-color);
-				padding-left: var(--d2l-left-icon-padding);
 			}
 
 			d2l-icon {

--- a/components/d2l-activity-link.js
+++ b/components/d2l-activity-link.js
@@ -109,7 +109,6 @@ class D2LActivityLink extends ASVFocusWithinMixin(PolymerASVLaunchMixin(Completi
 			}
 
 			.d2l-activity-link-title {
-				padding-right: var(--d2l-right-icon-padding);
 				word-wrap: break-word;
 				width: calc(
 					100% - 
@@ -143,6 +142,7 @@ class D2LActivityLink extends ASVFocusWithinMixin(PolymerASVLaunchMixin(Completi
 
 			d2l-completion-status {
 				width: var(--d2l-icon-size);
+				padding-left: var(--d2l-right-icon-padding);
 				color: var(--d2l-activity-link-text-color);
 			}
 

--- a/components/d2l-eol-activity-link.js
+++ b/components/d2l-eol-activity-link.js
@@ -19,6 +19,8 @@ class D2LEolActivityLink extends ASVFocusWithinMixin(PolymerASVLaunchMixin(Compl
 				--d2l-activity-link-text-color: var(--d2l-asv-text-color);
 				--d2l-activity-link-opacity: 1;
 				--d2l-activity-link-backdrop-opacity: 0;
+				--d2l-left-icon-padding: 15px;
+				--d2l-icon-size: 18px;
 				display: block;
 				cursor: pointer;
 				@apply --d2l-body-compact-text;
@@ -97,8 +99,12 @@ class D2LEolActivityLink extends ASVFocusWithinMixin(PolymerASVLaunchMixin(Compl
 			}
 
 			.d2l-activity-link-title {
-				padding-left: 15px;
-				flex: 1 100%;
+				word-wrap: break-word;
+				width: calc(
+					100% - 
+					var(--d2l-left-icon-padding) -
+					var(--d2l-icon-size)
+				);
 			}
 
 			a {
@@ -120,6 +126,7 @@ class D2LEolActivityLink extends ASVFocusWithinMixin(PolymerASVLaunchMixin(Compl
 
 			d2l-icon {
 				padding-top: 3px;
+				padding-right: var(--d2l-left-icon-padding);
 				color: var(--d2l-activity-link-text-color);
 			}
 

--- a/demo/data/m2-activity2.json
+++ b/demo/data/m2-activity2.json
@@ -4,6 +4,19 @@
 	},
 	"rel": ["item"],
 	"entities": [{
+			"class": [
+				"icon",
+				"tier1"
+			],
+			"rel": [
+				"icon"
+			],
+			"properties": {
+				"iconSetKey": "d2l-tier1:discussions",
+				"imagePath": "https://s.brightspace.com/lib/bsi/10.8.8-daylight.5/images/tier1/discussions.svg"
+			}
+		},
+		{
 		"links": [{
 			"rel": ["about"],
 			"href": "http://hdl.handle.net/10214/5312"
@@ -36,7 +49,7 @@
 				},
 				"rel": ["item"]
 			}],
-			"class": ["completion", "completed"]
+			"class": ["completion"]
 		}],
 		"actions": [{
 			"name": "view-activity",
@@ -64,7 +77,7 @@
 			"https://sequences.api.brightspace.com/rels/sequence-root"
 			],
 			"href": "data/lesson1.json"
-			
+
 	}],
 	"class": ["sequenced-activity"]
 }

--- a/demo/data/m2-activity3.json
+++ b/demo/data/m2-activity3.json
@@ -1,6 +1,6 @@
 {
 	"properties": {
-		"title": "Wikipedia Log super long title and items and things"
+		"title": "WikipediaLogsuperlongtitleanditemsandthingswordwordword"
 	},
 	"rel": ["item"],
 	"entities": [{

--- a/demo/data/m2-activity3.json
+++ b/demo/data/m2-activity3.json
@@ -1,6 +1,6 @@
 {
 	"properties": {
-		"title": "WikipediaLogsuperlongtitleanditemsandthingswordwordword"
+		"title": "ThisIs1ReallyLongWordddddddddddddddddddddddddddddddddddddddddddddddddddd."
 	},
 	"rel": ["item"],
 	"entities": [{

--- a/demo/index.html
+++ b/demo/index.html
@@ -50,7 +50,7 @@
 		<h3>Simple sequence-navigator</h3>
 		<demo-snippet>
 			<template>
-				<h4>Sequence navigator in a sidebar</h4>
+				<h4>Sequence navigator with no outer container</h4>
 				<d2l-sequence-navigator href="data/m2-activity2.json" token="foozleberries"
 					current-activity="data/m2-activity2.json">
 					<d2l-lesson-header slot="lesson-header"
@@ -61,6 +61,23 @@
 					<d2l-sequence-end slot="end-of-lesson" href="data/sequence-end.json" text="End of Sequence"
 						token="foozleberries"></d2l-sequence-end>
 				</d2l-sequence-navigator>
+			</template>
+		</demo-snippet>
+		<demo-snippet>
+			<template>
+				<h4>Sequence navigator contained in a 380px wide container</h4>
+				<div style="width: 380px">
+					<d2l-sequence-navigator href="data/m2-activity2.json" token="foozleberries"
+											current-activity="data/m2-activity2.json">
+						<d2l-lesson-header slot="lesson-header"
+										   href="data/lesson1.json"
+										   token="token"
+										   module-properties='{"moduleIndex":2,"numberOfSiblingModules":6,"title":"Testo Courso","useNewProgressBar":true}'>
+						</d2l-lesson-header>
+						<d2l-sequence-end slot="end-of-lesson" href="data/sequence-end.json" text="End of Sequence"
+										  token="foozleberries"></d2l-sequence-end>
+					</d2l-sequence-navigator>
+				</div>
 			</template>
 		</demo-snippet>
 		<demo-snippet>


### PR DESCRIPTION
There was missed spec on the previous pr where only the Unit Title length was fixed - however long Content Topic titles still caused some visual problems. This pr addresses that and should make the styling more robust.

I also fixed some "unrelated" stuff where text would not line up properly according to the mocks in scenarios like:
- There not being an icon on the content title
- The module being / not being completed

### SCREENSHOTS

In the demo with 380px wide bounding container:

![contenttitle-1](https://user-images.githubusercontent.com/14796305/66128503-ed09d380-e5bb-11e9-82a0-b11311f78a6c.PNG)


In the demo with no bounding container:

![contenttitle2](https://user-images.githubusercontent.com/14796305/66128508-f004c400-e5bb-11e9-8037-b1fb98ee23b0.PNG)


In the sequence-viewer demo:

![seqviewercontenttitle](https://user-images.githubusercontent.com/14796305/66128574-19255480-e5bc-11e9-98a4-c48509d9943b.PNG)


When a content title does not have a left icon:

![contenttitle7](https://user-images.githubusercontent.com/14796305/66129063-2858d200-e5bd-11e9-8df8-3edd6eb60974.PNG)


Missed activity module:

![missedactibityy](https://user-images.githubusercontent.com/14796305/66129292-9dc4a280-e5bd-11e9-8456-64c9e36da8d5.PNG)